### PR TITLE
fix ntorch.nn

### DIFF
--- a/namedtensor/test_module.py
+++ b/namedtensor/test_module.py
@@ -17,9 +17,11 @@ class NTModule(nn.Module):
         super(NTModule, self).__init__()
         self.w = ntorch.randn(dict(inhid=10, outhid=20))
         self.w_param = nn.Parameter(self.w._tensor)
+        self.w._tensor = self.w_param
 
         self.b = ntorch.randn(dict(outhid=20))
         self.b_param = nn.Parameter(self.b._tensor)
+        self.b._tensor = self.b_param
 
     def forward(self, inp):
         return inp.dot("inhid", self.w) + self.b

--- a/namedtensor/torch_nn.py
+++ b/namedtensor/torch_nn.py
@@ -11,20 +11,23 @@ class _Update:
 
     def __call__(self, input):
         updates = {} if "_updates" not in self.__dict__ else self._updates
-        return input.op(super(self.__class__, self).forward, **updates)
+        return input.op(super(_Update, self).forward, **updates)
 
 
 class _Flat:
     def __call__(self, input):
-        return input.op(super(self.__class__, self).forward)
+        return input.op(super(_Flat, self).forward)
 
 
 class _Loss:
-    def __call__(self, input, target):
-        assert self.reduction == "none"
-        reduced = input.dims[-1]
-        return input.reduce2(
-            target, super(self.__class__, self).forward, (reduced,)
+    def reduce(self, name):
+        self._reduced = name
+        return self
+
+    def __call__(self, inpu, target):
+        #assert self.reduction == "none"
+        return inpu.reduce2(
+            target, super(_Loss, self).forward, self._reduced
         )
 
 
@@ -33,12 +36,12 @@ class _Augment:
         self._augment = name
         return self
 
-    def forward(self, input, target):
+    def forward(self, input):
         augment = (
             "embedding" if "_augment" not in self.__dict__ else self._augment
         )
 
-        return input.augment(super(self.__class__, self).forward, augment)
+        return input.augment(super(_Augment, self).forward, augment)
 
 
 _wrap = ["Dropout"]


### PR DESCRIPTION
Feel free to edit this PR since I only tested on a logistic regression problem using Python 3.6. Maybe we need to write more test cases in the future.
1. super(self.__class__, self).forward seems to resolve to both parents since self.__class__ is the child class. By changing it to _Update or _Flat, we can prevent it from resolving to _Update or _Flat.
2. nn.Parameter seems to use different tensor storage than the originally provided one. (haven't fully tested yet, I observed that namedtensor._tensor.grad is None after backpropagation without this change).
3. (not fixed yet) I cannot do namedtensor / integer, but instead had to use namedtensor.div(integer).