### PR TITLE
Throw error when specified dimension for tensor contraction doesn't exist

### DIFF
--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -46,8 +46,9 @@ class NTorch(type):
             args.append(group)
         names = make_tuple(names)
         keep = [n for n in seen_names if n not in names]
-        if keep == seen_names:
-            raise RuntimeError("No dimension to contract")
+        for n in names:
+            if n not in seen_names:
+                raise RuntimeError("No dimension %s to contract along" % n)
         args.append([ids[n] for n in keep])
         return cls.tensor(oe.contract(*args, backend="torch"), keep)
 

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -1,7 +1,7 @@
 import torch
 from .torch_helpers import NamedTensor
 from . import torch_nn
-
+import warnings
 import opt_einsum as oe
 
 
@@ -47,6 +47,8 @@ class NTorch(type):
             args.append(group)
         names = make_tuple(names)
         keep = [n for n in seen_names if n not in names]
+        if(keep==seen_names):
+            warnings.warn("No dimension to contract")
         args.append([ids[n] for n in keep])
         return cls.tensor(oe.contract(*args, backend="torch"), keep)
 

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -1,7 +1,6 @@
 import torch
 from .torch_helpers import NamedTensor
 from . import torch_nn
-import warnings
 import opt_einsum as oe
 
 
@@ -47,8 +46,8 @@ class NTorch(type):
             args.append(group)
         names = make_tuple(names)
         keep = [n for n in seen_names if n not in names]
-        if(keep==seen_names):
-            warnings.warn("No dimension to contract")
+        if keep == seen_names:
+            raise RuntimeError("No dimension to contract")
         args.append([ids[n] for n in keep])
         return cls.tensor(oe.contract(*args, backend="torch"), keep)
 


### PR DESCRIPTION
I found it odd that

~~~
test1 = ntorch.randn({"width":300,"height":300,"channel":3})
test2 = ntorch.randn({"width":300,"height":300,"channel":3})
test1.dot("channle", test2) #oops a typo!
~~~

would just return the piecewise multiplication of the two tensors without complaining at all, so I added in an explicit warning that the dimension wasn't found.
