### PR TITLE
masked_index_updates

### DIFF
--- a/namedtensor/core.py
+++ b/namedtensor/core.py
@@ -196,10 +196,10 @@ class NamedTensorBase:
             order.append(d)
         return order
 
-    def _try_broadcast_order(self, main):
+    def _mask_broadcast_order(self, main):
         """
-        if broadcasting possible from self to main, outputs a shared order
-        otherwise errors and prints dimensions that exist in self but not main
+        if broadcasting possible from self (mask) to main, outputs a shared order
+        otherwise errors and prints dimensions that exist in mask but not main
         """
 
         to_be_broadcasted = set(self._schema._names)
@@ -209,7 +209,7 @@ class NamedTensorBase:
         diff_string = ", ".join(diff)
 
         assert len(diff) == 0, (
-            "Attemped to broadcast but unable to broadcast dimensions %s"
+            "Attemped to broadcast mask but unable to broadcast dimensions %s"
             % diff_string
         )
 

--- a/namedtensor/core.py
+++ b/namedtensor/core.py
@@ -173,7 +173,7 @@ class NamedTensorBase:
         return self._rearrange(term)
 
     def _force_order(self, names):
-        """ forces self to take order in names, adds 1-size dims if needed """
+        """ Forces self to take order in names, adds 1-size dims if needed """
         s = ""
         ex = []
         for d in names:
@@ -187,7 +187,7 @@ class NamedTensorBase:
         return self.__class__(tensor, ex)
 
     def _broadcast_order(self, other):
-        """ outputs a shared order (list) that works for self and other """
+        """ Outputs a shared order (list) that works for self and other """
         order = []
         for d in other._schema._names:
             if d not in self._schema._names:
@@ -198,8 +198,8 @@ class NamedTensorBase:
 
     def _mask_broadcast_order(self, main):
         """
-        if broadcasting possible from self (mask) to main, outputs a shared order
-        otherwise errors and prints dimensions that exist in mask but not main
+        If broadcasting possible from self (mask) to main, outputs a shared order.
+        Otherwise errors and prints dimensions that exist in mask but not in main.
         """
 
         to_be_broadcasted = set(self._schema._names)
@@ -213,10 +213,4 @@ class NamedTensorBase:
             % diff_string
         )
 
-        order = []
-        for d in main._schema._names:
-            if d not in self._schema._names:
-                order.append(d)
-        for d in self._schema._names:
-            order.append(d)
-        return order
+        return self._broadcast_order(main)

--- a/namedtensor/core.py
+++ b/namedtensor/core.py
@@ -173,6 +173,7 @@ class NamedTensorBase:
         return self._rearrange(term)
 
     def _force_order(self, names):
+        """ forces self to take order in names, adds 1-size dims if needed """
         s = ""
         ex = []
         for d in names:
@@ -186,8 +187,34 @@ class NamedTensorBase:
         return self.__class__(tensor, ex)
 
     def _broadcast_order(self, other):
+        """ outputs a shared order (list) that works for self and other """
         order = []
         for d in other._schema._names:
+            if d not in self._schema._names:
+                order.append(d)
+        for d in self._schema._names:
+            order.append(d)
+        return order
+
+    def _try_broadcast_order(self, main):
+        """
+        if broadcasting possible from self to main, outputs a shared order
+        otherwise errors and prints dimensions that exist in self but not main
+        """
+
+        to_be_broadcasted = set(self._schema._names)
+        broadcasted_to = set(main._schema._names)
+
+        diff = to_be_broadcasted.difference(broadcasted_to)
+        diff_string = ", ".join(diff)
+
+        assert len(diff) == 0, (
+            "Attemped to broadcast but unable to broadcast dimensions %s"
+            % diff_string
+        )
+
+        order = []
+        for d in main._schema._names:
             if d not in self._schema._names:
                 order.append(d)
         for d in self._schema._names:

--- a/namedtensor/test_core.py
+++ b/namedtensor/test_core.py
@@ -74,12 +74,14 @@ def test_mask():
     ntensor = t.masked_select(mask, "c")
     assert ntensor.shape == OrderedDict([("c", 2)])
 
+
 @pytest.mark.xfail
 def test_maskfail():
     t = ntorch.tensor(torch.Tensor([[1, 2], [3, 4]]), ("a", "b"))
     mask = ntorch.tensor(torch.ByteTensor([[0, 1], [1, 0]]), ("a", "banana"))
     ntensor = t.masked_select(mask, "c")
     assert ntensor.shape == OrderedDict([("c", 2)])
+
 
 def test_maskbroadcast():
     t = ntorch.tensor(torch.Tensor([[1, 2], [3, 4]]), ("a", "b"))

--- a/namedtensor/test_core.py
+++ b/namedtensor/test_core.py
@@ -74,6 +74,19 @@ def test_mask():
     ntensor = t.masked_select(mask, "c")
     assert ntensor.shape == OrderedDict([("c", 2)])
 
+@pytest.mark.xfail
+def test_maskfail():
+    t = ntorch.tensor(torch.Tensor([[1, 2], [3, 4]]), ("a", "b"))
+    mask = ntorch.tensor(torch.ByteTensor([[0, 1], [1, 0]]), ("a", "banana"))
+    ntensor = t.masked_select(mask, "c")
+    assert ntensor.shape == OrderedDict([("c", 2)])
+
+def test_maskbroadcast():
+    t = ntorch.tensor(torch.Tensor([[1, 2], [3, 4]]), ("a", "b"))
+    mask = ntorch.tensor(torch.ByteTensor([0, 1]), ("a"))
+    ntensor = t.masked_select(mask, "c")
+    assert ntensor.shape == OrderedDict([("c", 2)])
+
 
 def test_gather():
     t = torch.Tensor([[1, 2], [3, 4]])

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -85,11 +85,11 @@ class NTorch(type):
         return input._new(input.values.gather(dim, b1.values), updates=kwargs)
 
     @staticmethod
-    def masked_select(input, mask, dim):
-        order = input._broadcast_order(mask)
+    def masked_select(input, mask, name):
+        order = mask._try_broadcast_order(input)
         a1 = input._force_order(order)
         b1 = mask._force_order(order)
-        return NamedTensor(a1.values.masked_select(b1.values), dim)
+        return NamedTensor(a1.values.masked_select(b1.values), name)
 
     @staticmethod
     def scatter_(input, index, src, **kwargs):

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -86,7 +86,7 @@ class NTorch(type):
 
     @staticmethod
     def masked_select(input, mask, name):
-        order = mask._try_broadcast_order(input)
+        order = mask._mask_broadcast_order(input)
         a1 = input._force_order(order)
         b1 = mask._force_order(order)
         return NamedTensor(a1.values.masked_select(b1.values), name)

--- a/namedtensor/torch_helpers.py
+++ b/namedtensor/torch_helpers.py
@@ -65,11 +65,11 @@ class NamedTensor(NamedTensorBase):
 
         return ntorch.narrow(self, name, start, end)
 
-    def masked_select(self, mask, dim):
-        "Applies `mask` and returns a 1D tensor with name `dim`"
+    def masked_select(self, mask, name):
+        "Applies `mask` and returns a 1D tensor with name `name`"
         from .torch_base import ntorch
 
-        return ntorch.masked_select(self, mask, dim)
+        return ntorch.masked_select(self, mask, name)
 
     def relu(self):
         "Apply relu"


### PR DESCRIPTION
added _try_broadcast_order in core.py, which ensures the dimensions are able to be broadcasted before outputting order, update masked_index to use _try_broadcast_order instead of broadcast_order, update dim to name for masked_select args, added tests

try_broadcast_order can probably be applied to other functions as well that use broadcast_order