### PR TITLE
Added ntorch.nonzero

### DIFF
--- a/namedtensor/test_core.py
+++ b/namedtensor/test_core.py
@@ -260,32 +260,28 @@ def test_neg():
 def test_nonzero():
 
     # only zeros
-    x = ntorch.zeros(10, names=("alpha",))
+    x = ntorch.zeros(10, names=("alpha", "beta"))
     y = x.nonzero()
-    assert 0 == y.size('nonzero_el')
-    assert x.shape == OrderedDict([("alpha", 10)])
-    assert y.shape == OrderedDict([("nonzero_el", 0)])
+    assert 0 == y.size("nonzero_el")
+    assert x.shape == OrderedDict([("alpha", 10), ("beta", 1)])
+    assert y.shape == OrderedDict([("nonzero_el", 0), ("input_dims", 1)])
 
     # 1d tensor
-    x = ntorch.tensor([0,1,2,0,5], names=('dim',))
+    x = ntorch.tensor([0, 1, 2, 0, 5], names=("dim",))
     y = x.nonzero()
-    assert 3 == y.size('nonzero_el')
+    assert 3 == y.size("nonzero_el")
     assert x.shape == OrderedDict([("dim", 5)])
-    assert y.shape == OrderedDict([("nonzero_el", 3), ('input_dims', 1)])
-
+    assert y.shape == OrderedDict([("nonzero_el", 3), ("input_dims", 1)])
 
     # 2d tensor
     x = ntorch.tensor([[0.6, 0.0, 0.0, 0.0],
                        [0.0, 0.4, 0.0, 0.0],
                        [0.0, 0.0, 1.2, 0.0],
-                       [2.0, 0.0, 0.0,-0.4]], names=('alpha','beta'))
+                       [2.0, 0.0, 0.0, -0.4]], names=("alpha", "beta"))
     y = x.nonzero()
-    assert 5 == y.size('nonzero_el')
-    assert x.shape == OrderedDict([('alpha', 4), ('beta', 4)])
-    assert y.shape == OrderedDict([('nonzero_el', 5), ('input_dims', 2)])
-
-
-
+    assert 5 == y.size("nonzero_el")
+    assert x.shape == OrderedDict([("alpha", 4), ("beta", 4)])
+    assert y.shape == OrderedDict([("nonzero_el", 5), ("input_dims", 2)])
 
 
 # def test_scalar():

--- a/namedtensor/test_core.py
+++ b/namedtensor/test_core.py
@@ -265,6 +265,11 @@ def test_nonzero():
     assert 0 == y.size("elements_dim")
     assert x.shape == OrderedDict([("alpha", 10)])
     assert y.shape == OrderedDict([("elements_dim", 0), ("input_dims", 1)])
+    
+    # `names` length must be 2
+    y = x.nonzero(names=("a", "b"))
+    assert 0 == y.size("a")
+    assert y.shape == OrderedDict([("a", 0), ("b", 1)])
 
     # 1d tensor
     x = ntorch.tensor([0, 1, 2, 0, 5], names=("dim",))
@@ -272,6 +277,11 @@ def test_nonzero():
     assert 3 == y.size("elements_dim")
     assert x.shape == OrderedDict([("dim", 5)])
     assert y.shape == OrderedDict([("elements_dim", 3), ("input_dims", 1)])
+    
+    # `names` length must be 2
+    y = x.nonzero(names=("a", "b"))
+    assert 3 == y.size("a")
+    assert y.shape == OrderedDict([("a", 3), ("b", 1)])
 
     # 2d tensor
     x = ntorch.tensor([[0.6, 0.0, 0.0, 0.0],
@@ -282,6 +292,23 @@ def test_nonzero():
     assert 5 == y.size("elements_dim")
     assert x.shape == OrderedDict([("alpha", 4), ("beta", 4)])
     assert y.shape == OrderedDict([("elements_dim", 5), ("input_dims", 2)])
+
+    # `names` length must be 2
+    y = x.nonzero(names=("a", "b"))
+    assert 5 == y.size("a")
+    assert y.shape == OrderedDict([("a", 5), ("b", 2)])
+
+
+@pytest.mark.xfail
+def test_nonzero_names():
+
+    # `names` length must be 2
+    x = ntorch.tensor([0, 1, 2, 0, 5], names=("dim",))
+    y = x.nonzero(names=("a",))
+
+    # `names` length must be 2
+    x = ntorch.tensor([0, 1, 2, 0, 5], names=("dim",))
+    y = x.nonzero(names=("a", "b", "c"))
 
 
 # def test_scalar():

--- a/namedtensor/test_core.py
+++ b/namedtensor/test_core.py
@@ -260,18 +260,18 @@ def test_neg():
 def test_nonzero():
 
     # only zeros
-    x = ntorch.zeros(10, names=("alpha", "beta"))
+    x = ntorch.zeros(10, names=("alpha",))
     y = x.nonzero()
-    assert 0 == y.size("nonzero_el")
-    assert x.shape == OrderedDict([("alpha", 10), ("beta", 1)])
-    assert y.shape == OrderedDict([("nonzero_el", 0), ("input_dims", 1)])
+    assert 0 == y.size("elements_dim")
+    assert x.shape == OrderedDict([("alpha", 10)])
+    assert y.shape == OrderedDict([("elements_dim", 0), ("input_dims", 1)])
 
     # 1d tensor
     x = ntorch.tensor([0, 1, 2, 0, 5], names=("dim",))
     y = x.nonzero()
-    assert 3 == y.size("nonzero_el")
+    assert 3 == y.size("elements_dim")
     assert x.shape == OrderedDict([("dim", 5)])
-    assert y.shape == OrderedDict([("nonzero_el", 3), ("input_dims", 1)])
+    assert y.shape == OrderedDict([("elements_dim", 3), ("input_dims", 1)])
 
     # 2d tensor
     x = ntorch.tensor([[0.6, 0.0, 0.0, 0.0],
@@ -279,9 +279,9 @@ def test_nonzero():
                        [0.0, 0.0, 1.2, 0.0],
                        [2.0, 0.0, 0.0, -0.4]], names=("alpha", "beta"))
     y = x.nonzero()
-    assert 5 == y.size("nonzero_el")
+    assert 5 == y.size("elements_dim")
     assert x.shape == OrderedDict([("alpha", 4), ("beta", 4)])
-    assert y.shape == OrderedDict([("nonzero_el", 5), ("input_dims", 2)])
+    assert y.shape == OrderedDict([("elements_dim", 5), ("input_dims", 2)])
 
 
 # def test_scalar():

--- a/namedtensor/test_core.py
+++ b/namedtensor/test_core.py
@@ -257,6 +257,37 @@ def test_neg():
     assert_match(-base, expected)
 
 
+def test_nonzero():
+
+    # only zeros
+    x = ntorch.zeros(10, names=("alpha",))
+    y = x.nonzero()
+    assert 0 == y.size('nonzero_el')
+    assert x.shape == OrderedDict([("alpha", 10)])
+    assert y.shape == OrderedDict([("nonzero_el", 0)])
+
+    # 1d tensor
+    x = ntorch.tensor([0,1,2,0,5], names=('dim',))
+    y = x.nonzero()
+    assert 3 == y.size('nonzero_el')
+    assert x.shape == OrderedDict([("dim", 5)])
+    assert y.shape == OrderedDict([("nonzero_el", 3), ('input_dims', 1)])
+
+
+    # 2d tensor
+    x = ntorch.tensor([[0.6, 0.0, 0.0, 0.0],
+                       [0.0, 0.4, 0.0, 0.0],
+                       [0.0, 0.0, 1.2, 0.0],
+                       [2.0, 0.0, 0.0,-0.4]], names=('alpha','beta'))
+    y = x.nonzero()
+    assert 5 == y.size('nonzero_el')
+    assert x.shape == OrderedDict([('alpha', 4), ('beta', 4)])
+    assert y.shape == OrderedDict([('nonzero_el', 5), ('input_dims', 2)])
+
+
+
+
+
 # def test_scalar():
 #     base1 = ntorch.randn(dict(alpha=10, beta=2, gamma=50))
 #     base2 = base1 + 10

--- a/namedtensor/test_core.py
+++ b/namedtensor/test_core.py
@@ -265,7 +265,7 @@ def test_nonzero():
     assert 0 == y.size("elements_dim")
     assert x.shape == OrderedDict([("alpha", 10)])
     assert y.shape == OrderedDict([("elements_dim", 0), ("input_dims", 1)])
-    
+
     # `names` length must be 2
     y = x.nonzero(names=("a", "b"))
     assert 0 == y.size("a")
@@ -277,7 +277,7 @@ def test_nonzero():
     assert 3 == y.size("elements_dim")
     assert x.shape == OrderedDict([("dim", 5)])
     assert y.shape == OrderedDict([("elements_dim", 3), ("input_dims", 1)])
-    
+
     # `names` length must be 2
     y = x.nonzero(names=("a", "b"))
     assert 3 == y.size("a")
@@ -305,10 +305,12 @@ def test_nonzero_names():
     # `names` length must be 2
     x = ntorch.tensor([0, 1, 2, 0, 5], names=("dim",))
     y = x.nonzero(names=("a",))
+    assert 2 == len(y.shape)
 
     # `names` length must be 2
     x = ntorch.tensor([0, 1, 2, 0, 5], names=("dim",))
     y = x.nonzero(names=("a", "b", "c"))
+    assert 2 == len(y.shape)
 
 
 # def test_scalar():

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -92,9 +92,9 @@ class NTorch(type):
         return NamedTensor(a1.values.masked_select(b1.values), dim)
 
     @staticmethod
-    def nonzero(tensor):
+    def nonzero(tensor, elements_dim="elements_dim"):
         indices = torch.nonzero(tensor.values)
-        names = ["nonzero_el"]
+        names = [elements_dim]
         if indices.numel() > 0:
             names.append("input_dims")
         return NamedTensor(tensor=indices, names=tuple(names))

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -94,11 +94,10 @@ class NTorch(type):
     @staticmethod
     def nonzero(tensor):
         indices = torch.nonzero(tensor.values)
-        names = ['nonzero_el']
+        names = ["nonzero_el"]
         if indices.numel() > 0:
-            names.append('input_dims')
+            names.append("input_dims")
         return NamedTensor(tensor=indices, names=tuple(names))
-
 
     @staticmethod
     def scatter_(input, index, src, **kwargs):

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -95,13 +95,13 @@ class NTorch(type):
     def nonzero(tensor, names=("elements_dim", "input_dims")):
         """
         Returns a tensor containing the indices of all non-zero elements.
-        
+
         Parameters
         ----------
         names : tuple, optional
             Names for the output dimensions
             default value: ("elements_dim", "input_dims")
-            default output shape: OrderedDict([("elements_dim", number of non-zero elements), 
+            default output shape: OrderedDict([("elements_dim", number of non-zero elements),
                                                  ("input_dims", input tensor's number of dimensions)])
         """
 

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -92,6 +92,15 @@ class NTorch(type):
         return NamedTensor(a1.values.masked_select(b1.values), dim)
 
     @staticmethod
+    def nonzero(tensor):
+        indices = torch.nonzero(tensor.values)
+        names = ['nonzero_el']
+        if indices.numel() > 0:
+            names.append('input_dims')
+        return NamedTensor(tensor=indices, names=tuple(names))
+
+
+    @staticmethod
     def scatter_(input, index, src, **kwargs):
         indim = tuple(kwargs.keys())[0]
         outdim = kwargs[indim]

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -94,10 +94,8 @@ class NTorch(type):
     @staticmethod
     def nonzero(tensor, elements_dim="elements_dim"):
         indices = torch.nonzero(tensor.values)
-        names = [elements_dim]
-        if indices.numel() > 0:
-            names.append("input_dims")
-        return NamedTensor(tensor=indices, names=tuple(names))
+        names = (elements_dim, "input_dims")
+        return NamedTensor(tensor=indices, names=names)
 
     @staticmethod
     def scatter_(input, index, src, **kwargs):

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -98,6 +98,7 @@ class NTorch(type):
 
         Parameters
         ----------
+        tensor: NamedTensor
         names : tuple, optional
             Names for the output dimensions
             default value: ("elements_dim", "input_dims")

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -92,9 +92,20 @@ class NTorch(type):
         return NamedTensor(a1.values.masked_select(b1.values), dim)
 
     @staticmethod
-    def nonzero(tensor, elements_dim="elements_dim"):
+    def nonzero(tensor, names=("elements_dim", "input_dims")):
+        """
+        Returns a tensor containing the indices of all non-zero elements.
+        
+        Parameters
+        ----------
+        names : tuple, optional
+            Names for the output dimensions
+            default value: ("elements_dim", "input_dims")
+            default output shape: OrderedDict([("elements_dim", number of non-zero elements), 
+                                                 ("input_dims", input tensor's number of dimensions)])
+        """
+
         indices = torch.nonzero(tensor.values)
-        names = (elements_dim, "input_dims")
         return NamedTensor(tensor=indices, names=names)
 
     @staticmethod

--- a/namedtensor/torch_helpers.py
+++ b/namedtensor/torch_helpers.py
@@ -71,6 +71,11 @@ class NamedTensor(NamedTensorBase):
 
         return ntorch.masked_select(self, mask, dim)
 
+    def nonzero(self):
+        "Returns a tensor containing the indices of all non-zero elements"
+        from .torch_base import ntorch
+        return ntorch.nonzero(self)
+
     def relu(self):
         "Apply relu"
         return self._new(F.relu(self._tensor))

--- a/namedtensor/torch_helpers.py
+++ b/namedtensor/torch_helpers.py
@@ -74,13 +74,13 @@ class NamedTensor(NamedTensorBase):
     def nonzero(self, names=("elements_dim", "input_dims")):
         """
         Returns a tensor containing the indices of all non-zero elements.
-        
+
         Parameters
         ----------
         names : tuple, optional
             Names for the output dimensions
             default value: ("elements_dim", "input_dims")
-            default output shape: OrderedDict([("elements_dim", number of non-zero elements), 
+            default output shape: OrderedDict([("elements_dim", number of non-zero elements),
                                                  ("input_dims", input tensor's number of dimensions)])
         """
 

--- a/namedtensor/torch_helpers.py
+++ b/namedtensor/torch_helpers.py
@@ -71,10 +71,21 @@ class NamedTensor(NamedTensorBase):
 
         return ntorch.masked_select(self, mask, dim)
 
-    def nonzero(self):
-        "Returns a tensor containing the indices of all non-zero elements"
+    def nonzero(self, names=("elements_dim", "input_dims")):
+        """
+        Returns a tensor containing the indices of all non-zero elements.
+        
+        Parameters
+        ----------
+        names : tuple, optional
+            Names for the output dimensions
+            default value: ("elements_dim", "input_dims")
+            default output shape: OrderedDict([("elements_dim", number of non-zero elements), 
+                                                 ("input_dims", input tensor's number of dimensions)])
+        """
+
         from .torch_base import ntorch
-        return ntorch.nonzero(self)
+        return ntorch.nonzero(self, names)
 
     def relu(self):
         "Apply relu"


### PR DESCRIPTION
Hi! I'm not sure about the names for the dimensions of the output tensor that contains the indices. Now I'm using: names = ("nonzero_el", "input_dims").