### PR TITLE
Wrap names in __init__ as tuple if not already a tuple.

### DIFF
--- a/namedtensor/core.py
+++ b/namedtensor/core.py
@@ -1,4 +1,5 @@
 from .schema import _Schema
+from .utils import make_tuple
 from einops import rearrange
 
 
@@ -29,10 +30,9 @@ class NamedTensorBase:
     """
 
     def __init__(self, tensor, names, mask=0):
+        names = make_tuple(names)
         self._tensor = tensor
         self._schema = _Schema.build(names, mask)
-        if not isinstance(names, tuple):
-            names = (names,)
         assert len(self._tensor.shape) == len(self._schema._names), (
             "Tensor has %d dim, but only %d names"
             % (len(self._tensor.shape), len(self._schema._names))

--- a/namedtensor/core.py
+++ b/namedtensor/core.py
@@ -31,8 +31,10 @@ class NamedTensorBase:
     def __init__(self, tensor, names, mask=0):
         self._tensor = tensor
         self._schema = _Schema.build(names, mask)
+        if not isinstance(names, tuple):
+            names = (names,)
         assert len(self._tensor.shape) == len(self._schema._names), (
-            "Tensor has  %d dim, but only %d names"
+            "Tensor has %d dim, but only %d names"
             % (len(self._tensor.shape), len(self._schema._names))
         )
 

--- a/namedtensor/core.py
+++ b/namedtensor/core.py
@@ -1,5 +1,4 @@
 from .schema import _Schema
-from .utils import make_tuple
 from einops import rearrange
 
 
@@ -30,7 +29,6 @@ class NamedTensorBase:
     """
 
     def __init__(self, tensor, names, mask=0):
-        names = make_tuple(names)
         self._tensor = tensor
         self._schema = _Schema.build(names, mask)
         assert len(self._tensor.shape) == len(self._schema._names), (

--- a/namedtensor/schema.py
+++ b/namedtensor/schema.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-
+from .utils import make_tuple
 
 class _Schema:
     "Dimension names and order"

--- a/namedtensor/schema.py
+++ b/namedtensor/schema.py
@@ -5,7 +5,7 @@ class _Schema:
     "Dimension names and order"
 
     def __init__(self, names, mask=0):
-        self._names = tuple(names)
+        self._names = make_tuple(names)
         for n in self._names:
             assert n is not None
         self._masked = mask
@@ -21,6 +21,7 @@ class _Schema:
     def build(names, mask):
         if isinstance(names, _Schema):
             return _Schema(names._names, mask)
+        names = make_tuple(names)
         return _Schema(names, mask)
 
     def get(self, name):

--- a/namedtensor/schema.py
+++ b/namedtensor/schema.py
@@ -35,8 +35,7 @@ class _Schema:
         return i
 
     def drop(self, names):
-        if not isinstance(names, tuple):
-            names = (names,)
+        names = make_tuple(names)
         return _Schema(
             [n for n in self._names if n not in names], self._masked
         )

--- a/namedtensor/schema.py
+++ b/namedtensor/schema.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from .utils import make_tuple
 
+
 class _Schema:
     "Dimension names and order"
 

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -4,6 +4,7 @@ from .utils import make_tuple
 from . import torch_nn
 import opt_einsum as oe
 
+
 class NTorch(type):
     def __getattr__(cls, name):
         if name in cls._build:

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -27,7 +27,7 @@ class NTorch(type):
 
     @classmethod
     def dot(cls, dims, *tensors):
-        names = dims
+        names = make_tuple(dims)
         args = []
         ids = {}
         seen_names = []
@@ -40,7 +40,6 @@ class NTorch(type):
                 group.append(ids[name])
             args.append(t._tensor)
             args.append(group)
-        names = make_tuple(names)
         keep = [n for n in seen_names if n not in names]
         for n in names:
             if n not in seen_names:

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -1,18 +1,8 @@
 import torch
 from .torch_helpers import NamedTensor
+from .utils import make_tuple
 from . import torch_nn
 import opt_einsum as oe
-
-
-def make_tuple(names):
-    if names is None:
-        return ()
-
-    if isinstance(names, tuple):
-        return names
-    else:
-        return (names,)
-
 
 class NTorch(type):
     def __getattr__(cls, name):

--- a/namedtensor/torch_helpers.py
+++ b/namedtensor/torch_helpers.py
@@ -2,6 +2,7 @@ import torch.nn.functional as F
 from .core import NamedTensorBase, assert_match
 from .utils import make_tuple
 
+
 class NamedTensor(NamedTensorBase):
     def index_select(self, dim, index):
         "Index into dimension names with the `index` named tensors."

--- a/namedtensor/torch_helpers.py
+++ b/namedtensor/torch_helpers.py
@@ -1,17 +1,6 @@
 import torch.nn.functional as F
 from .core import NamedTensorBase, assert_match
-
-
-def make_tuple(names):
-    if names is None:
-        return ()
-    if isinstance(names, tuple):
-        return names
-    if isinstance(names, list):
-        return tuple(names)
-    else:
-        return (names,)
-
+from .utils import make_tuple
 
 class NamedTensor(NamedTensorBase):
     def index_select(self, dim, index):

--- a/namedtensor/utils.py
+++ b/namedtensor/utils.py
@@ -1,0 +1,9 @@
+def make_tuple(names):
+    if names is None:
+        return ()
+    if isinstance(names, tuple):
+        return names
+    if isinstance(names, list):
+        return tuple(names)
+    else:
+        return (names,)


### PR DESCRIPTION
This prevents undesired behavior when `names` is an iterable.
For example, it fixes the fact that `ntorch.ones(1,2, names="ab")` runs without error.
Meanwhile, it avoids the unhelpful error messages when running, say, `ntorch.ones(3, names=("vocab"))`, which without the fix results in `AssertionError: Tensor has  1 dim, but only 5 names`.

Fixed a typo'd extra space in the above AssertionError message.