### PR TITLE
Proposal for indexing notation

### DIFF
--- a/namedtensor/nn/torch_nn.py
+++ b/namedtensor/nn/torch_nn.py
@@ -51,7 +51,9 @@ class _Loss:
             input = input.transpose(*self._input_order).contiguous()
             return input.reduce2(target, super(_Loss, self).forward, reduced)
         else:
-            assert "_reduced" in dir(self), "Call 'spec' with target dimension."
+            assert "_reduced" in dir(
+                self
+            ), "Call 'spec' with target dimension."
             return input.reduce2(
                 target, super(_Loss, self).forward, self._reduced
             )

--- a/namedtensor/test_core.py
+++ b/namedtensor/test_core.py
@@ -390,6 +390,79 @@ def test_log_softmax():
     assert_match(base, expected)
 
 
+def test_indexing():
+
+    base = ntorch.randn(10, 2, 50, names=("alpha", "beta", "gamma"))
+
+    base1 = base[{"alpha": 2}]
+    assert base1.shape == OrderedDict([("beta", 2), ("gamma", 50)])
+
+
+    base1 = base[{"beta": 0}]
+    assert base1.shape == OrderedDict([("alpha", 10), ("gamma", 50)])
+
+    base1 = base[{"alpha": (2, 5)}]
+    assert base1.shape == OrderedDict([("alpha", 3), ("beta", 2), ("gamma", 50)])
+
+
+def test_index_set():
+
+    base = ntorch.randn(10, 2, 50, names=("alpha", "beta", "gamma"))
+    new = ntorch.randn(2, 50, names=( "beta", "gamma"))
+
+    base[{"alpha": 2}] = new
+
+    new = ntorch.randn(3, 2, 50, names=( "alpha", "beta", "gamma"))
+    base[{"alpha": (0, 3)}] = new
+
+
+def test_tensor_mask():
+    base = ntorch.zeros(10, 2, 50, names=("alpha", "beta", "gamma"))
+    base[{"alpha": (2, 5), "gamma": (4, 6)}] = 1
+
+
+    mask = base > 0.5
+    base1 = base[mask]
+    assert base1.shape == OrderedDict([("on", 12)])
+    base[mask] = 6
+    print(base[{"alpha": 2, "gamma": 4, "beta": 0}])
+    assert base[{"alpha": 2, "gamma": 4, "beta": 0}].values == 6
+
+
+def test_index_tensor():
+    base = ntorch.zeros(10, 2, 50, names=("alpha", "beta", "gamma"))
+    indices = ntorch.tensor([1,2,3,4], names=("indices"))
+    base1 = base[{"gamma": indices}]
+    assert base1.shape == OrderedDict([("alpha", 10), ("beta", 2), ("indices", 4)])
+
+    indices = ntorch.tensor([1,2,3,4], names=("indices"))
+    base1 = base[{"alpha": 1, "gamma": indices}]
+    assert base1.shape == OrderedDict([("beta", 2), ("indices", 4)])
+
+    indices = ntorch.tensor([[1,2,3],[1,2,3]] , names=("d", "indices"))
+    base1 = base[{"gamma": indices}]
+    assert base1.shape == OrderedDict([("alpha", 10), ("beta", 2),
+                                       ("d", 2), ("indices", 3)])
+
+def test_setindex_tensor():
+    base = ntorch.zeros(10, 2, 50, names=("alpha", "beta", "gamma")).float()
+    indices = ntorch.tensor([1,2,3,4], names=("indices")).long()
+    vals = ntorch.tensor([52,23.0,42.9,4.2], names=("indices")).float()
+    b = base[{"alpha": 1, "beta": 1}]
+    b[{"gamma": indices}] = vals
+    assert base[{"alpha": 1, "beta": 1, "gamma": 1}].values == 52
+
+    base[{"gamma": indices}] = 2
+
+
+    # mask = base > 0.5
+    # base1 = base[mask]
+    # assert base1.shape == OrderedDict([("on", 12)])
+    # base[mask] = 6
+    # print(base[{"alpha": 2, "gamma": 4, "beta": 0}])
+    # assert base[{"alpha": 2, "gamma": 4, "beta": 0}].values == 6
+
+
 # def test_scalar():
 #     base1 = ntorch.randn(dict(alpha=10, beta=2, gamma=50))
 #     base2 = base1 + 10

--- a/namedtensor/test_core.py
+++ b/namedtensor/test_core.py
@@ -115,8 +115,7 @@ def test_gather():
     index = ntorch.tensor(torch.LongTensor([[0, 0], [1, 0]]), ("a", "c"))
     ntensor = ntorch.gather(t, "b", index, "c")
     assert (ntensor.values == base).all()
-    assert ntensor.shape == OrderedDict(
-        [("a", 2), ("c", 2)])
+    assert ntensor.shape == OrderedDict([("a", 2), ("c", 2)])
 
     x = ntorch.tensor(torch.rand(2, 5), ("c", "b"))
     y = ntorch.tensor(torch.rand(3, 5), ("a", "b"))
@@ -397,29 +396,29 @@ def test_indexing():
     base1 = base[{"alpha": 2}]
     assert base1.shape == OrderedDict([("beta", 2), ("gamma", 50)])
 
-
     base1 = base[{"beta": 0}]
     assert base1.shape == OrderedDict([("alpha", 10), ("gamma", 50)])
 
     base1 = base[{"alpha": (2, 5)}]
-    assert base1.shape == OrderedDict([("alpha", 3), ("beta", 2), ("gamma", 50)])
+    assert base1.shape == OrderedDict(
+        [("alpha", 3), ("beta", 2), ("gamma", 50)]
+    )
 
 
 def test_index_set():
 
     base = ntorch.randn(10, 2, 50, names=("alpha", "beta", "gamma"))
-    new = ntorch.randn(2, 50, names=( "beta", "gamma"))
+    new = ntorch.randn(2, 50, names=("beta", "gamma"))
 
     base[{"alpha": 2}] = new
 
-    new = ntorch.randn(3, 2, 50, names=( "alpha", "beta", "gamma"))
+    new = ntorch.randn(3, 2, 50, names=("alpha", "beta", "gamma"))
     base[{"alpha": (0, 3)}] = new
 
 
 def test_tensor_mask():
     base = ntorch.zeros(10, 2, 50, names=("alpha", "beta", "gamma"))
     base[{"alpha": (2, 5), "gamma": (4, 6)}] = 1
-
 
     mask = base > 0.5
     base1 = base[mask]
@@ -431,29 +430,32 @@ def test_tensor_mask():
 
 def test_index_tensor():
     base = ntorch.zeros(10, 2, 50, names=("alpha", "beta", "gamma"))
-    indices = ntorch.tensor([1,2,3,4], names=("indices"))
+    indices = ntorch.tensor([1, 2, 3, 4], names=("indices"))
     base1 = base[{"gamma": indices}]
-    assert base1.shape == OrderedDict([("alpha", 10), ("beta", 2), ("indices", 4)])
+    assert base1.shape == OrderedDict(
+        [("alpha", 10), ("beta", 2), ("indices", 4)]
+    )
 
-    indices = ntorch.tensor([1,2,3,4], names=("indices"))
+    indices = ntorch.tensor([1, 2, 3, 4], names=("indices"))
     base1 = base[{"alpha": 1, "gamma": indices}]
     assert base1.shape == OrderedDict([("beta", 2), ("indices", 4)])
 
-    indices = ntorch.tensor([[1,2,3],[1,2,3]] , names=("d", "indices"))
+    indices = ntorch.tensor([[1, 2, 3], [1, 2, 3]], names=("d", "indices"))
     base1 = base[{"gamma": indices}]
-    assert base1.shape == OrderedDict([("alpha", 10), ("beta", 2),
-                                       ("d", 2), ("indices", 3)])
+    assert base1.shape == OrderedDict(
+        [("alpha", 10), ("beta", 2), ("d", 2), ("indices", 3)]
+    )
+
 
 def test_setindex_tensor():
     base = ntorch.zeros(10, 2, 50, names=("alpha", "beta", "gamma")).float()
-    indices = ntorch.tensor([1,2,3,4], names=("indices")).long()
-    vals = ntorch.tensor([52,23.0,42.9,4.2], names=("indices")).float()
+    indices = ntorch.tensor([1, 2, 3, 4], names=("indices")).long()
+    vals = ntorch.tensor([52, 23.0, 42.9, 4.2], names=("indices")).float()
     b = base[{"alpha": 1, "beta": 1}]
     b[{"gamma": indices}] = vals
     assert base[{"alpha": 1, "beta": 1, "gamma": 1}].values == 52
 
     base[{"gamma": indices}] = 2
-
 
     # mask = base > 0.5
     # base1 = base[mask]

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -97,7 +97,6 @@ class NTorch(type):
         b1 = mask._force_order(order)
         return NamedTensor(a1.values.masked_select(b1.values), name)
 
-
     @staticmethod
     def masked_scatter_(input, mask, source):
         order = mask._mask_broadcast_order(input)
@@ -105,14 +104,12 @@ class NTorch(type):
         input.values.masked_scatter_(b1.values, source.values)
         return input
 
-
     @staticmethod
     def masked_fill_(input, mask, value):
         order = mask._mask_broadcast_order(input)
         b1 = mask._force_order(order)
         input.values.masked_fill_(b1.values, value)
         return input
-
 
     @staticmethod
     def nonzero(tensor, names=("elements", "inputdims")):

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -97,6 +97,23 @@ class NTorch(type):
         b1 = mask._force_order(order)
         return NamedTensor(a1.values.masked_select(b1.values), name)
 
+
+    @staticmethod
+    def masked_scatter_(input, mask, source):
+        order = mask._mask_broadcast_order(input)
+        b1 = mask._force_order(order)
+        input.values.masked_scatter_(b1.values, source.values)
+        return input
+
+
+    @staticmethod
+    def masked_fill_(input, mask, value):
+        order = mask._mask_broadcast_order(input)
+        b1 = mask._force_order(order)
+        input.values.masked_fill_(b1.values, value)
+        return input
+
+
     @staticmethod
     def nonzero(tensor, names=("elements", "inputdims")):
         """

--- a/namedtensor/torch_helpers.py
+++ b/namedtensor/torch_helpers.py
@@ -1,10 +1,9 @@
 import torch.nn.functional as F
 from .core import NamedTensorBase, assert_match
 from .utils import make_tuple
-import torch
+
 
 class NamedTensor(NamedTensorBase):
-
     def _index_base(self, dim, index):
         name = dim
         new_names = []
@@ -32,19 +31,25 @@ class NamedTensor(NamedTensorBase):
     def index_fill_(self, dim, index, val):
         "Index into dimension names with the `index` named tensors."
         self._tensor.index_fill_(
-            self._schema.get(dim), index._tensor.view(-1), val)
+            self._schema.get(dim), index._tensor.view(-1), val
+        )
         return self
 
     def index_copy_(self, dim, index, source):
         "Index into dimension names with the `index` named tensors."
         order = source._mask_broadcast_order(index)
         source = source._force_order(order)
-        print(self.values.shape, index.values.shape, self._schema.get(dim), index.values,
-              source.values
+        print(
+            self.values.shape,
+            index.values.shape,
+            self._schema.get(dim),
+            index.values,
+            source.values,
         )
 
         self.values.index_copy_(
-            self._schema.get(dim), index.values, source.values)
+            self._schema.get(dim), index.values, source.values
+        )
 
         return self
 
@@ -53,7 +58,7 @@ class NamedTensor(NamedTensorBase):
             cur = self
             for k, v in index.items():
                 if isinstance(v, tuple):
-                    cur = cur.narrow(k, v[0], v[1]-v[0])
+                    cur = cur.narrow(k, v[0], v[1] - v[0])
                 elif isinstance(v, NamedTensor):
                     cur = cur.index_select(k, v)
                 else:
@@ -101,7 +106,6 @@ class NamedTensor(NamedTensorBase):
         else:
             raise RuntimeError("Index must be dict or namedtensor.")
         return self
-
 
     def copy_(self, other):
         order = other._mask_broadcast_order(self)
@@ -270,7 +274,7 @@ class NamedTensor(NamedTensorBase):
         return self.sub(b)
 
     def __rsub__(self, b):
-        return - self.sub(b)
+        return -self.sub(b)
 
     def __mul__(self, b):
         return self.mul(b)
@@ -437,10 +441,7 @@ class NamedTensor(NamedTensorBase):
         "trunc",
     }
 
-    _noshift_dim = {
-        "cumprod",
-        "cumsum",
-    }
+    _noshift_dim = {"cumprod", "cumsum"}
 
     # Return a non-tensor info object
     _info = {


### PR DESCRIPTION
several people requested this, so here is a alpha version
* a[{"dim": 5}] => index into "dim" (edited) 
* a[{"dim": (1,5)}] => slice into "dim"
* a[{"dim": 5, "dim2": (2,4)}] => both
* a[ b > 20 ] => shortcut notation for masked select (edited) 
* a[ b > 20 ] = 10 => shortcut notation for masked fill
* a[ b > 20 ] = c => shortcut notation for masked copy
* a[{"dim": b}] => index select along "dim" based on b