### PR TITLE
ntorch.cat/stack will automatically reorder tensors

### DIFF
--- a/namedtensor/test_core.py
+++ b/namedtensor/test_core.py
@@ -130,12 +130,24 @@ def test_gather():
     assert y.shape == OrderedDict([("a", 3), ("b", 5)])
 
 
+def test_cat():
+    x = ntorch.zeros(20, 10, names=("a", "b"))
+    y = ntorch.ones(30, 20, names=("b", "a"))
+    assert ntorch.cat([x, y], dim="b").shape == OrderedDict(
+        [("a", 20), ("b", 40)]
+    )
+
+
 def test_stack():
-    tensor_a = ntorch.tensor(torch.Tensor([[1, 2], [3, 4]]), ("dim1", "dim2"))
-    tensor_b = ntorch.tensor(torch.Tensor([[1, 2], [3, 4]]), ("dim1", "dim2"))
+    tensor_a = ntorch.tensor(
+        torch.Tensor([[1, 2], [3, 4], [5, 6]]), ("dim1", "dim2")
+    )
+    tensor_b = ntorch.tensor(
+        torch.Tensor([[1, 2, 3], [4, 5, 6]]), ("dim2", "dim1")
+    )
     tensor_c = ntorch.stack([tensor_a, tensor_b], "dim3")
     assert tensor_c.shape == OrderedDict(
-        [("dim3", 2), ("dim1", 2), ("dim2", 2)]
+        [("dim3", 2), ("dim1", 3), ("dim2", 2)]
     )
 
 

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -61,7 +61,9 @@ class NTorch(type):
         old_names = tensors[0]._schema._names
         for i in range(1, len(tensors)):
             if tensors[i]._schema._names != old_names:
-                if set(tensors[i]._schema._names) != set(tensors[0]._schema._names):
+                if set(tensors[i]._schema._names) != set(
+                    tensors[0]._schema._names
+                ):
                     raise RuntimeError(
                         "Tensors to stack don't have matching dimension names"
                     )
@@ -77,7 +79,9 @@ class NTorch(type):
         dim = tensors[0]._schema.get(dim)
         for i in range(1, len(tensors)):
             if tensors[i]._schema._names != tensors[0]._schema._names:
-                if set(tensors[i]._schema._names) != set(tensors[0]._schema._names):
+                if set(tensors[i]._schema._names) != set(
+                    tensors[0]._schema._names
+                ):
                     raise RuntimeError(
                         "Tensors to stack don't have matching dimension names"
                     )


### PR DESCRIPTION
Currently the following code:

`x = ntorch.zeros(20, 10, names=("a", "b"))`
`y = ntorch.ones(30, 20, names=("b", "a"))`
`torch.cat([x, y], dim = 'b')`

Raises an assertion error because the dimensions of x and y are in different order. This should prevent that from happening. (Having named dimensions means that you shouldn't need to call transpose repeatedly to line up your tensors).