### PR TITLE
Update torch_nn.py

### DIFF
--- a/namedtensor/nn/torch_nn.py
+++ b/namedtensor/nn/torch_nn.py
@@ -211,9 +211,9 @@ class _RNN:
 
         # For some reason, even with batch_first pytorch returns
         # the state with batch second. Need to transpose it.
-        state_value = run(state, lambda x: x.values.transpose(0, 1))
+        state_value = run(state, lambda x: x.values.transpose(0, 1).contiguous())
         output, state = super(_RNN, self).forward(input.values, state_value)
-        state = run(state, lambda x: x.transpose(0, 1))
+        state = run(state, lambda x: x.transpose(0, 1).contiguous())
 
         updates = self._output_update
         updates2 = dict(updates)


### PR DESCRIPTION
As pointed out by Michael Lingzhi Li:
There seems to be something going on with using RNN with defined hidden states in NamedTensor
`rnn = ntorch.nn.RNN(50, 20, 2).cuda()`
`rnn.spec("input", "time", "out")`
`a, b = rnn(ntorch.randn(20, 10, 50, names=("batch", "time", "input")).cuda(),ntorch.randn(20, 2, 20, names=("batch", "layers", "out")).cuda())`
This code doesnt work and says "hx is not contiguous"
while the non-cuda version works