### PR TITLE
Padpack

### DIFF
--- a/namedtensor/nn/torch_nn.py
+++ b/namedtensor/nn/torch_nn.py
@@ -1,5 +1,8 @@
 import torch.nn as nn
 from ..torch_helpers import NamedTensor
+from torch.nn.utils.rnn import pack_padded_sequence as pack
+from torch.nn.utils.rnn import pad_packed_sequence as unpack
+
 
 
 class Module(nn.Module):
@@ -313,7 +316,7 @@ Embedding.__doc__ = nn.Embedding.__doc__
 
 
 class _RNN:
-    def __call__(self, input, state=None):
+    def __call__(self, input, state=None, lengths=None):
         input = input.transpose(*self._input_order).contiguous()
 
         def run(v, fn):
@@ -326,10 +329,17 @@ class _RNN:
 
         # For some reason, even with batch_first pytorch returns
         # the state with batch second. Need to transpose it.
+        state_order = (self._layer_name, "batch", self._name_out)
         state_value = run(
-            state, lambda x: x.values.transpose(0, 1).contiguous()
+            state,
+            lambda x: x._force_order(state_order).values
         )
-        output, state = super(_RNN, self).forward(input.values, state_value)
+        if lengths is None:
+            output, state = super(_RNN, self).forward(input.values, state_value)
+        else:
+            output, state = super(_RNN, self).forward(
+                pack(input.values, lengths, True), state_value)
+            output = unpack(output, True)[0]
         state = run(state, lambda x: x.transpose(0, 1).contiguous())
 
         updates = self._output_update

--- a/namedtensor/nn/torch_nn.py
+++ b/namedtensor/nn/torch_nn.py
@@ -4,7 +4,6 @@ from torch.nn.utils.rnn import pack_padded_sequence as pack
 from torch.nn.utils.rnn import pad_packed_sequence as unpack
 
 
-
 class Module(nn.Module):
     def register_parameter(self, name, tensor):
         if isinstance(tensor, NamedTensor):

--- a/namedtensor/nn/torch_nn.py
+++ b/namedtensor/nn/torch_nn.py
@@ -338,7 +338,7 @@ class _RNN:
             output, state = super(_RNN, self).forward(input.values, state_value)
         else:
             output, state = super(_RNN, self).forward(
-                pack(input.values, lengths, True), state_value)
+                pack(input.values, lengths.values, True), state_value)
             output = unpack(output, True)[0]
         state = run(state, lambda x: x.transpose(0, 1).contiguous())
 

--- a/namedtensor/text/torch_text.py
+++ b/namedtensor/text/torch_text.py
@@ -14,13 +14,13 @@ class NamedField(torchtext.data.Field):
     def numericalize(self, arr, device=None):
         vals = super(NamedField, self).numericalize(arr, device=device)
 
-        if vals is list or vals is tuple:
+        if isinstance(vals, list) or isinstance(vals, tuple):
             assert len(vals) == 2
             var, lengths = vals
             if self.sequential and not self.batch_first:
-                var = NamedTensor(vals, self.names + ("batch",))
+                var = NamedTensor(var, self.names + ("batch",))
             else:
-                var = NamedTensor(vals, ("batch",) + self.names)
+                var = NamedTensor(var, ("batch",) + self.names)
                 lengths = NamedTensor(lengths, ("batch",))
             return var, lengths
 


### PR DESCRIPTION
Open to changing this, since it assumes that there exists a dimension named "batch" which is the batch dimension in order to get the hidden state into the right format regardless of ordering.