### PR TITLE
"reciprical" > "reciprocal"

### DIFF
--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -326,7 +326,7 @@ class NTorch(type):
         "log",
         "mul",
         "pow",
-        "reciprical",
+        "reciprocal",
         "relu",
         "round",
         "rsqrt",

--- a/namedtensor/torch_helpers.py
+++ b/namedtensor/torch_helpers.py
@@ -347,6 +347,7 @@ class NamedTensor(NamedTensorBase):
         "int",
         "long",
         "log",
+        "reciprocal",
         "relu",
         "round",
         "rsqrt",
@@ -363,7 +364,7 @@ class NamedTensor(NamedTensorBase):
         "trunc",
     }
 
-    _noshift_args = {"pow", "fmod", "clamp", "reciprical"}
+    _noshift_args = {"pow", "fmod", "clamp"}
 
     _noshift_nn = {"relu"}
 


### PR DESCRIPTION
fixed two instances of `reciprical` to `reciprocal`, and moved `reciprocal` from `_noshift_args` to `_noshift` (because it takes no args)