### PR TITLE
added the ability to iterate over named tensors

### DIFF
--- a/namedtensor/test_core.py
+++ b/namedtensor/test_core.py
@@ -627,6 +627,17 @@ def test_setindex_tensor():
     base[{"gamma": indices}] = 2
 
 
+def test_iter():
+    tensor = torch.Tensor([[1, 2], [3, 4], [5, 6]])
+    ntensor = ntorch.tensor(tensor, ("a", "b"))
+
+    for i, e in enumerate(ntensor.iter("a")):
+        assert (e.values == tensor[i, :]).all()
+
+    for i, e in enumerate(ntensor.iter("b")):
+        assert (e.values == tensor[:, i]).all()
+
+
 @pytest.mark.xfail
 def test_unique_names():
     base = torch.zeros([10, 2])

--- a/namedtensor/torch_helpers.py
+++ b/namedtensor/torch_helpers.py
@@ -83,6 +83,10 @@ class NamedTensor(NamedTensorBase):
             self.values.narrow(dim, torch.tensor(idx), 1).squeeze(dim), name
         )
 
+    def iter(self, dim):
+        for i in range(self.shape[dim]):
+            yield self.get(dim, i)
+
     def renorm(self, p, name, maxnorm):
         "Apply :py:meth:`torch.Tensor.renorm` over `name`"
         results = self._tensor.renorm(p, self.get(name), maxnorm)


### PR DESCRIPTION
Having the ability to iterate over named tensors makes a lot of things a lot more convenient.

Example usage:
```
for seq in minibatch.iter("batch"):
    prediction = f(seq)
```