### PR TITLE
Fix unique

### DIFF
--- a/namedtensor/test_core.py
+++ b/namedtensor/test_core.py
@@ -49,6 +49,12 @@ def test_deepcopy(x):
 def test_unique(data, x):
     s = data.draw(dim(x))
     nu, ni = data.draw(names(x, max_size=2))
+    output = ntorch.unique(
+        x, sorted=True, return_inverse=False, names=(nu, ni)
+    )
+    assert set(output.dims) == set([nu])
+    output = ntorch.unique(x, sorted=True, names=(nu, ni))
+    assert set(output.dims) == set([nu])
     output, inverse_indices = ntorch.unique(
         x, sorted=True, return_inverse=True, dim=s, names=(nu, ni)
     )

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -139,13 +139,11 @@ class NTorch(type):
         """
         dim_name = dim
         return_inverse = "return_inverse" in kwargs and kwargs["return_inverse"]
-        if dim is not None:
-            dim = input._schema.get(dim)
-        output, inverse_indices = torch._unique(input.values, dim=dim, **kwargs)
-
         # If dim is not None, the output ntensor has the same dimensions as input while the dim is renamed,
         # and the inverse_indices is an 1-D ntensor.
-        if dim_name is not None:
+        if dim is not None:
+            dim = input._schema.get(dim)
+            output, inverse_indices = torch._unique_dim(input.values, dim=dim, **kwargs)
             output = NamedTensor(output, input.dims).rename(
                 dim_name, (names[0])
             )
@@ -154,6 +152,7 @@ class NTorch(type):
         # If dim is None, the output is an 1-D ntensor,
         # and the inverse_indices has the same dimensions as input while the dimensions are renamed.
         else:
+            output, inverse_indices = torch._unique(input.values, **kwargs)
             output = NamedTensor(output, names[0])
             if return_inverse:
                 inverse_indices = NamedTensor(

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -138,12 +138,16 @@ class NTorch(type):
 
         """
         dim_name = dim
-        return_inverse = "return_inverse" in kwargs and kwargs["return_inverse"]
+        return_inverse = (
+            "return_inverse" in kwargs and kwargs["return_inverse"]
+        )
         # If dim is not None, the output ntensor has the same dimensions as input while the dim is renamed,
         # and the inverse_indices is an 1-D ntensor.
         if dim is not None:
             dim = input._schema.get(dim)
-            output, inverse_indices = torch._unique_dim(input.values, dim=dim, **kwargs)
+            output, inverse_indices = torch._unique_dim(
+                input.values, dim=dim, **kwargs
+            )
             output = NamedTensor(output, input.dims).rename(
                 dim_name, (names[0])
             )
@@ -156,7 +160,8 @@ class NTorch(type):
             output = NamedTensor(output, names[0])
             if return_inverse:
                 inverse_indices = NamedTensor(
-                    inverse_indices, (["%s%s" % (s, names[1]) for s in input.dims])
+                    inverse_indices,
+                    (["%s%s" % (s, names[1]) for s in input.dims]),
                 )
         if return_inverse:
             return output, inverse_indices

--- a/namedtensor/torch_base.py
+++ b/namedtensor/torch_base.py
@@ -140,8 +140,11 @@ class NTorch(type):
         dim_name = dim
         if dim is not None:
             dim = input._schema.get(dim)
-        output, inverse_indices = torch.unique(input.values, dim=dim, **kwargs)
-
+        output = torch.unique(input.values, dim=dim, **kwargs)
+        
+        if not "return_inverse" in kwargs or not kwargs["return_inverse"]:
+            return output
+        output, inverse_indices = output
         # If dim is not None, the output ntensor has the same dimensions as input while the dim is renamed,
         # and the inverse_indices is an 1-D ntensor.
         if dim_name is not None:


### PR DESCRIPTION
Problem: torch.unique doesn't output `inverse_indices` unless `return_inverse==True`, so I'd get a "too many values to unpack" error if `return_inverse==False`
Fix: unpack only if `return_inverse==True`